### PR TITLE
Add global leaderboard to speedrun mode

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,14 +4,13 @@
   <meta charset="utf-8">
   <title>Super McCrario Bros</title>
   <style>
-    #control-row {
+    #timer-leaderboard-row {
       display: flex;
       align-items: flex-start;
       gap: 40px;
     }
-    #speedrun-row {
-      display: flex;
-      gap: 40px;
+    #timer-section {
+      width: 110px;
     }
   </style>
 </head>
@@ -20,52 +19,47 @@
   <canvas id="game" width="800" height="600"></canvas>
   <div id="info">
     <p><a href="https://github.com/brandonpickering/super-mccrario-bros">Source on GitHub</a></p>
-    <div id="control-row">
-      <div>
-        <h2>Debug controls</h2>
-        <ul>
-          <li>Press '`' (backtick) to toggle between debug and release mode.</li>
-          <li>Press 'F' to toggle flying. While flying, you do not collide with walls or other entities.</li>
-          <li>Press Backspace to reset checkpoints.</li>
-          <li>Press 'L' or F9 to load a level.</li>
-          <li>Press Esc or F5 to save a level.</li>
-          <li>Press 'Q' and 'E' to switch between types.</li>
-          <li>Left click to place a tile.</li>
-          <li>Right click to replace a tile with air.</li>
-          <li>Click outside the bounds of the level to expand it.</li>
-          <li>Middle click a border row or column to remove it.</li>
-          <li>Press 'R' to switch into entity mode.</li>
-          <li>In entity mode, left click to place an entity seed of the displayed entity.</li>
-          <li>Right click a seed to remove it.</li>
-          <li>Middle click a seed to spawn its entity.</li>
-        </ul>
+    <div id="timer-leaderboard-row">
+      <div id="timer-section">
+        <h2>Timer</h2>
+        <table id="speedrun">
+          <tr><td>Level 1</td><td id="sr-l1"></td></tr>
+          <tr><td>Level 2</td><td id="sr-l2"></td></tr>
+          <tr><td>Level 3</td><td id="sr-l3"></td></tr>
+          <tr><td>Level 4</td><td id="sr-l4"></td></tr>
+          <tr><td>Boss</td><td id="sr-boss"></td></tr>
+          <tr><td>Total</td><td id="sr-total"></td></tr>
+        </table>
       </div>
       <div>
-        <h2>Speedrun</h2>
-        <div id="speedrun-row">
-          <table id="speedrun">
-            <tr><td>Level 1</td><td id="sr-l1"></td></tr>
-            <tr><td>Level 2</td><td id="sr-l2"></td></tr>
-            <tr><td>Level 3</td><td id="sr-l3"></td></tr>
-            <tr><td>Level 4</td><td id="sr-l4"></td></tr>
-            <tr><td>Boss</td><td id="sr-boss"></td></tr>
-            <tr><td>Total</td><td id="sr-total"></td></tr>
-          </table>
-          <div>
-            <h3>Leaderboard</h3>
-            <table id="leaderboard">
-              <thead>
-                <tr><th>Rank</th><th>Username</th><th>Total Time</th></tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-            <div>
-              <input type="text" id="username" placeholder="Username">
-              <button id="set-username">Set Username</button>
-            </div>
-          </div>
+        <h2>Leaderboard</h2>
+        <table id="leaderboard">
+          <tbody></tbody>
+        </table>
+        <div>
+          <input type="text" id="username" placeholder="Name">
+          <button id="set-username">Set name</button>
         </div>
       </div>
+    </div>
+    <div>
+      <h2>Debug controls</h2>
+      <ul>
+        <li>Press '`' (backtick) to toggle between debug and release mode.</li>
+        <li>Press 'F' to toggle flying. While flying, you do not collide with walls or other entities.</li>
+        <li>Press Backspace to reset checkpoints.</li>
+        <li>Press 'L' or F9 to load a level.</li>
+        <li>Press Esc or F5 to save a level.</li>
+        <li>Press 'Q' and 'E' to switch between types.</li>
+        <li>Left click to place a tile.</li>
+        <li>Right click to replace a tile with air.</li>
+        <li>Click outside the bounds of the level to expand it.</li>
+        <li>Middle click a border row or column to remove it.</li>
+        <li>Press 'R' to switch into entity mode.</li>
+        <li>In entity mode, left click to place an entity seed of the displayed entity.</li>
+        <li>Right click a seed to remove it.</li>
+        <li>Middle click a seed to spawn its entity.</li>
+      </ul>
     </div>
   </div>
   <script type="module" src="./dist/Main.js"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,10 @@
       align-items: flex-start;
       gap: 40px;
     }
+    #speedrun-row {
+      display: flex;
+      gap: 40px;
+    }
   </style>
 </head>
 <body>
@@ -38,14 +42,29 @@
       </div>
       <div>
         <h2>Speedrun</h2>
-        <table id="speedrun">
-          <tr><td>Level 1</td><td id="sr-l1"></td></tr>
-          <tr><td>Level 2</td><td id="sr-l2"></td></tr>
-          <tr><td>Level 3</td><td id="sr-l3"></td></tr>
-          <tr><td>Level 4</td><td id="sr-l4"></td></tr>
-          <tr><td>Boss</td><td id="sr-boss"></td></tr>
-          <tr><td>Total</td><td id="sr-total"></td></tr>
-        </table>
+        <div id="speedrun-row">
+          <table id="speedrun">
+            <tr><td>Level 1</td><td id="sr-l1"></td></tr>
+            <tr><td>Level 2</td><td id="sr-l2"></td></tr>
+            <tr><td>Level 3</td><td id="sr-l3"></td></tr>
+            <tr><td>Level 4</td><td id="sr-l4"></td></tr>
+            <tr><td>Boss</td><td id="sr-boss"></td></tr>
+            <tr><td>Total</td><td id="sr-total"></td></tr>
+          </table>
+          <div>
+            <h3>Leaderboard</h3>
+            <table id="leaderboard">
+              <thead>
+                <tr><th>Rank</th><th>Username</th><th>Total Time</th></tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+            <div>
+              <input type="text" id="username" placeholder="Username">
+              <button id="set-username">Set Username</button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/web/src/Leaderboard.ts
+++ b/web/src/Leaderboard.ts
@@ -85,6 +85,9 @@ export class Leaderboard {
     });
     const entries = await res.json();
     this.leaderboardBody.textContent = '';
+    const header = document.createElement('tr');
+    header.innerHTML = '<th>Rank</th><th>Name</th><th>Total Time</th>';
+    this.leaderboardBody.appendChild(header);
     for (const entry of entries) {
       const tr = document.createElement('tr');
       if (entry.isRequester) tr.style.fontWeight = 'bold';

--- a/web/src/Leaderboard.ts
+++ b/web/src/Leaderboard.ts
@@ -1,0 +1,101 @@
+const API_BASE = 'https://4hqqcv02r4.execute-api.us-east-2.amazonaws.com/Prod';
+
+function pad2(n: number): string {
+  return n < 10 ? '0' + n : '' + n;
+}
+
+function formatTime(t: number): string {
+  const tenths = Math.floor(t * 10);
+  const minutes = Math.floor(tenths / 600);
+  const seconds = Math.floor((tenths / 10) % 60);
+  const tenth = tenths % 10;
+  return `${pad2(minutes)}:${pad2(seconds)}.${tenth}`;
+}
+
+export class Leaderboard {
+  private static deviceID: string;
+  private static leaderboardBody: HTMLTableSectionElement;
+  private static usernameInput: HTMLInputElement;
+  private static setUsernameBtn: HTMLButtonElement;
+
+  static async init() {
+    this.deviceID = this.getDeviceID();
+    this.leaderboardBody = document.querySelector('#leaderboard tbody')!;
+    this.usernameInput = document.getElementById('username') as HTMLInputElement;
+    this.setUsernameBtn = document.getElementById('set-username') as HTMLButtonElement;
+    this.setUsernameBtn.addEventListener('click', () => this.setUsername());
+    await this.loadUsername();
+    await this.refresh();
+  }
+
+  private static getDeviceID(): string {
+    const match = document.cookie.match(/(?:^|; )deviceID=([^;]+)/);
+    if (match) return match[1];
+    const id = crypto.randomUUID();
+    document.cookie = `deviceID=${id}; path=/; max-age=${60 * 60 * 24 * 365}`;
+    return id;
+  }
+
+  static async recordRun(data: object) {
+    const runID = crypto.randomUUID();
+    await fetch(`${API_BASE}/recordRun`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        gameID: 'super-mccrario-bros',
+        runID,
+        deviceID: this.deviceID,
+        data,
+      }),
+    });
+    await this.refresh();
+  }
+
+  private static async loadUsername() {
+    const res = await fetch(`${API_BASE}/username`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceID: this.deviceID }),
+    });
+    const json = await res.json();
+    if (json.username) this.usernameInput.value = json.username;
+  }
+
+  private static async setUsername() {
+    const username = this.usernameInput.value.trim();
+    if (!username) return;
+    await fetch(`${API_BASE}/setUsername`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceID: this.deviceID, username }),
+    });
+    await this.refresh();
+  }
+
+  static async refresh() {
+    const res = await fetch(`${API_BASE}/leaderboard`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        gameID: 'super-mccrario-bros',
+        metric: 'totalTime',
+        order: 'ascending',
+        deviceID: this.deviceID,
+      }),
+    });
+    const entries = await res.json();
+    this.leaderboardBody.textContent = '';
+    for (const entry of entries) {
+      const tr = document.createElement('tr');
+      if (entry.isRequester) tr.style.fontWeight = 'bold';
+      const rank = document.createElement('td');
+      rank.textContent = entry.rank.toString();
+      const user = document.createElement('td');
+      user.textContent = entry.username;
+      const time = document.createElement('td');
+      time.textContent = formatTime(entry.data.totalTime);
+      tr.append(rank, user, time);
+      this.leaderboardBody.appendChild(tr);
+    }
+  }
+}

--- a/web/src/Main.ts
+++ b/web/src/Main.ts
@@ -1,9 +1,11 @@
 import { Game } from './Game.js';
 import { Speedrun } from './Speedrun.js';
+import { Leaderboard } from './Leaderboard.js';
 
 window.addEventListener('load', () => {
   const canvas = document.getElementById('game') as HTMLCanvasElement;
   Speedrun.init();
+  void Leaderboard.init();
   const game = new Game(canvas);
   game.start();
 });

--- a/web/src/Speedrun.ts
+++ b/web/src/Speedrun.ts
@@ -1,4 +1,5 @@
 import { DebugInfo } from './DebugInfo.js';
+import { Leaderboard } from './Leaderboard.js';
 
 function pad2(n: number): string {
   return n < 10 ? '0' + n : '' + n;
@@ -65,6 +66,16 @@ export class Speedrun {
   static finishGame() {
     this.totalActive = false;
     this.repaint();
+    if (!this.totalInvalid && this.totalTime > 0) {
+      void Leaderboard.recordRun({
+        level1Time: this.levelTimes[0],
+        level2Time: this.levelTimes[1],
+        level3Time: this.levelTimes[2],
+        level4Time: this.levelTimes[3],
+        bossTime: this.levelTimes[4],
+        totalTime: this.totalTime,
+      });
+    }
   }
 
   static update(delta: number) {


### PR DESCRIPTION
## Summary
- Record valid runs to global leaderboard and fetch top scores
- Persist device ID in cookies and allow username management
- Display leaderboard beside current run times

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896657f9ce48320b3a315c42362e21b